### PR TITLE
Replace dead links and update donations

### DIFF
--- a/scripts/create-everything-list.js
+++ b/scripts/create-everything-list.js
@@ -48,14 +48,15 @@ const listsToIncludeInEverythingList = [
 `# ------------------------------------[UPDATE]--------------------------------------
 # Title: The Block List Project - Everything List
 # Expires: 1 day
-# Homepage: https://blocklist.site
+# Homepage: https://blocklistproject.github.io/Lists/
 # Help: https://github.com/blocklistproject/lists/wiki/
 # License: https://unlicense.org
 # Total number of network filters:
 # ------------------------------------[SUPPORT]-------------------------------------
 # You can support by:
 # - reporting false positives
-# - making a donation: https://paypal.me/blocklistproject
+# - making a donation via paypal: https://paypal.me/blocklistproject
+# - making a donation via patreon: https://www.patreon.com/theblocklistproject
 # -------------------------------------[INFO]---------------------------------------
 #
 # Everything list


### PR DESCRIPTION
## Summary

The https://blocklist.site page seems to be dead/domain expired, and the patreon donations link in github repo wasn't in the lists for some reason. Therefore I updated the page to a new one and added both the links.

## Checklist

- [x] I have verified that I have not modified the following files:
      - inside the `adguard` folder
      - inside the `alt-version` folder
      - inside the `dnsmasq-version` folder
      - everything.txt

Because those files will be automatically updated using GitHub Actions!

